### PR TITLE
Support multiple validators

### DIFF
--- a/contracts/ListaStakeManager.sol
+++ b/contracts/ListaStakeManager.sol
@@ -1,0 +1,865 @@
+//SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/AddressUpgradeable.sol";
+
+import {IStakeManager} from "./interfaces/IStakeManager.sol";
+import {ISLisBNB} from "./interfaces/ISLisBNB.sol";
+import {IStaking} from "./interfaces/INativeStaking.sol";
+
+/**
+ * @title Stake Manager Contract
+ * @dev Handles Staking of BNB on BSC
+ */
+contract ListaStakeManager is
+    IStakeManager,
+    Initializable,
+    PausableUpgradeable,
+    AccessControlUpgradeable
+{
+    using SafeERC20Upgradeable for IERC20Upgradeable;
+
+    uint256 public totalSnBnbToBurn;
+
+    uint256 public totalDelegated; // total BNB delegated
+    uint256 public amountToDelegate; // total BNB to delegate for next batch
+
+    uint256 public nextUndelegateUUID;
+    uint256 public confirmedUndelegatedUUID;
+
+    uint256 public reserveAmount; // will be used to adjust minThreshold delegate/undelegate for natvie staking
+    uint256 public totalReserveAmount;
+
+    address private snBnb;
+    address private bcValidator;
+
+    mapping(uint256 => BotUndelegateRequest)
+        private uuidToBotUndelegateRequestMap;
+    mapping(address => WithdrawalRequest[]) private userWithdrawalRequests;
+
+    uint256 public constant TEN_DECIMALS = 1e10;
+    bytes32 public constant BOT = keccak256("BOT");
+
+    address private manager;
+    address private proposedManager;
+    uint256 public synFee; // range {0-10_000_000_000}
+
+    address public revenuePool;
+    address public redirectAddress;
+
+    address private constant NATIVE_STAKING = 0x0000000000000000000000000000000000002001;
+
+    uint256 private spareSlisBnb; // extra slisBnb from last undelegate operation by bot
+    uint256 public nextClaimableIndex; // the index pf next claimable request in queue
+    mapping(address => ValidatorStatus) public validators;
+    UserRequest[] internal withdrawalQueue; // queue for requested withdawals
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    /**
+     * @param _slisBnb - Address of SlisBnb Token on Binance Smart Chain
+     * @param _admin - Address of the admin
+     * @param _manager - Address of the manager
+     * @param _bot - Address of the Bot
+     * @param _synFee - Rewards fee to revenue pool
+     * @param _revenuePool - Revenue pool to receive rewards
+     * @param _validator - Validator to delegate BNB
+     */
+    function initialize(
+        address _slisBnb,
+        address _admin,
+        address _manager,
+        address _bot,
+        uint256 _synFee,
+        address _revenuePool,
+        address _validator
+    ) external override initializer {
+        __AccessControl_init();
+        __Pausable_init();
+
+        require(
+            ((_slisBnb != address(0)) &&
+                (_admin != address(0)) &&
+                (_manager != address(0)) &&
+                (_validator != address(0)) &&
+                (_revenuePool != address(0)) &&
+                (_bot != address(0))),
+            "zero address provided"
+        );
+        require(_synFee <= TEN_DECIMALS, "_synFee must not exceed (100%)");
+
+        _setRoleAdmin(BOT, DEFAULT_ADMIN_ROLE);
+        _setupRole(DEFAULT_ADMIN_ROLE, _admin);
+        _setupRole(BOT, _bot);
+
+        manager = _manager;
+        snBnb = _slisBnb;
+        bcValidator = _validator;
+        synFee = _synFee;
+        revenuePool = _revenuePool;
+
+        emit SetManager(_manager);
+        emit SetBCValidator(bcValidator);
+        emit SetRevenuePool(revenuePool);
+        emit SetSynFee(_synFee);
+    }
+
+    /**
+     * @dev Allows user to deposit Bnb at BSC and mints SlisBnb for the user
+     */
+    function deposit() external payable override whenNotPaused {
+        uint256 amount = msg.value;
+        require(amount > 0, "Invalid Amount");
+
+        uint256 slisBnbToMint = convertBnbToSlisBnb(amount);
+        require(slisBnbToMint > 0, "Invalid SlisBnb Amount");
+        amountToDelegate += amount;
+
+        ISLisBNB(snBnb).mint(msg.sender, slisBnbToMint);
+
+        emit Deposit(msg.sender, msg.value);
+    }
+
+    /**
+     * @dev Allows bot to delegate users' funds to native staking contract without reserved BNB
+     * @return _amount - Amount of funds transferred for staking
+     * @notice The amount should be greater than minimum delegation on native staking contract
+     */
+    function delegate()
+        external
+        payable
+        override
+        whenNotPaused
+        onlyRole(BOT)
+        returns (uint256 _amount)
+    {
+        uint256 relayFee = IStaking(NATIVE_STAKING).getRelayerFee();
+        uint256 relayFeeReceived = msg.value;
+        _amount = amountToDelegate - (amountToDelegate % TEN_DECIMALS);
+
+        require(relayFeeReceived == relayFee, "Insufficient RelayFee");
+        require(_amount >= IStaking(NATIVE_STAKING).getMinDelegation(), "Insufficient Deposit Amount");
+
+        amountToDelegate = amountToDelegate - _amount;
+        totalDelegated += _amount;
+
+        // delegate through native staking contract
+        IStaking(NATIVE_STAKING).delegate{value: _amount + msg.value}(bcValidator, _amount);
+
+        emit Delegate(_amount);
+    }
+
+    /**
+     * @dev Allows bot to delegate users' funds + reserved BNB to native staking contract
+     * @return _amount - Amount of funds transferred for staking
+     * @notice The amount should be greater than minimum delegation on native staking contract
+     */
+    function delegateWithReserve()
+        external
+        payable
+        override
+        whenNotPaused
+        onlyRole(BOT)
+        returns (uint256 _amount)
+    {
+        uint256 relayFee = IStaking(NATIVE_STAKING).getRelayerFee();
+        uint256 relayFeeReceived = msg.value;
+        _amount = amountToDelegate - (amountToDelegate % TEN_DECIMALS);
+
+        require(relayFeeReceived == relayFee, "Insufficient RelayFee");
+        require(totalReserveAmount >= reserveAmount, "Insufficient Reserve Amount");
+        require(_amount + reserveAmount >= IStaking(NATIVE_STAKING).getMinDelegation(), "Insufficient Deposit Amount");
+
+        amountToDelegate = amountToDelegate - _amount;
+        totalDelegated += _amount;
+
+        // delegate through native staking contract
+        IStaking(NATIVE_STAKING).delegate{value: _amount + msg.value + reserveAmount}(bcValidator, _amount + reserveAmount);
+
+        emit Delegate(_amount);
+        emit DelegateReserve(reserveAmount);
+    }
+
+    /**
+     * @dev Allows bot to delegate users' funds to native staking contract without reserved BNB
+     * @param _validator - Address of the validator to delegate to
+     * @param _amt - Amount of BNB to delegate
+     * @notice The amount should be greater than minimum delegation on native staking contract
+     */
+    function delegateTo(address _validator, uint256 _amt)
+        external
+        payable
+        override
+        whenNotPaused
+        onlyRole(BOT)
+        returns (uint256 _amount)
+    {
+	require(amountToDelegate >= _amt, "Not enough BNB to delegate");
+	uint256 relayFee = IStaking(NATIVE_STAKING).getRelayerFee();
+        uint256 relayFeeReceived = msg.value;
+        _amount = _amt - (_amt % TEN_DECIMALS);
+
+	require(validators[_validator].active == true, "Inactive validator");
+        require(relayFeeReceived == relayFee, "Insufficient RelayFee");
+        require(_amount >= IStaking(NATIVE_STAKING).getMinDelegation(), "Insufficient Deposit Amount");
+
+        amountToDelegate = amountToDelegate - _amount;
+        totalDelegated += _amount;
+	validators[_validator].amount += _amount;
+
+        // delegate through native staking contract
+        IStaking(NATIVE_STAKING).delegate{value: _amount + msg.value}(_validator, _amount);
+
+        emit DelegateTo(_validator, _amount);
+    }
+
+    function redelegate(address srcValidator, address dstValidator, uint256 amount)
+        external
+        payable
+        override
+        whenNotPaused
+        onlyManager
+        returns (uint256 _amount)
+    {
+        uint256 relayFee = IStaking(NATIVE_STAKING).getRelayerFee();
+        uint256 relayFeeReceived = msg.value;
+
+        require(srcValidator != dstValidator, "Invalid Redelegation");
+        require(relayFeeReceived == relayFee, "Insufficient RelayFee");
+        require(amount >= IStaking(NATIVE_STAKING).getMinDelegation(), "Insufficient Deposit Amount");
+	require(validators[srcValidator].amount >= amount, "Insufficient balance of srcValidator");
+
+	validators[srcValidator].amount -= amount;
+	validators[dstValidator].amount += amount;
+        // redelegate through native staking contract
+        IStaking(NATIVE_STAKING).redelegate{value: msg.value}(srcValidator, dstValidator, amount);
+
+        emit ReDelegate(srcValidator, dstValidator, amount);
+
+        return amount;
+    }
+    /**
+     * @dev Allows bot to compound rewards
+     */
+    function compoundRewards()
+        external
+        override
+        whenNotPaused
+        onlyRole(BOT)
+    {
+        require(totalDelegated > 0, "No funds delegated");
+
+        uint256 amount = IStaking(NATIVE_STAKING).claimReward();
+
+        if (synFee > 0) {
+            uint256 fee = amount * synFee / TEN_DECIMALS;
+            require(revenuePool != address(0x0), "revenue pool not set");
+            AddressUpgradeable.sendValue(payable(revenuePool), fee);
+            amount -= fee;
+        }
+
+        amountToDelegate += amount;
+
+        emit RewardsCompounded(amount);
+    }
+
+    /**
+     * @dev Allows user to request for unstake/withdraw funds
+     * @param _amountInSlisBnb - Amount of SlisBnb to swap for withdraw
+     * @notice User must have approved this contract to spend SnBnb
+     */
+    function requestWithdraw(uint256 _amountInSlisBnb)
+        external
+        override
+        whenNotPaused
+    {
+        require(_amountInSlisBnb > 0, "Invalid Amount");
+
+        totalSnBnbToBurn += _amountInSlisBnb;
+        uint256 totalBnbToWithdraw = convertSlisBnbToBnb(totalSnBnbToBurn);
+        require(
+            totalBnbToWithdraw <= totalDelegated + amountToDelegate,
+            "Not enough BNB to withdraw"
+        );
+
+        userWithdrawalRequests[msg.sender].push(
+            WithdrawalRequest({
+                uuid: type(uint256).max, // uuid to be decided
+                amountInSnBnb: _amountInSlisBnb,
+                startTime: block.timestamp
+            })
+        );
+
+	withdrawalQueue.push(
+	    UserRequest({
+		user: msg.sender,
+		idx: userWithdrawalRequests[msg.sender].length - 1 // position in mapping
+	    })
+	);
+
+        IERC20Upgradeable(snBnb).safeTransferFrom(
+            msg.sender,
+            address(this),
+            _amountInSlisBnb
+        );
+        emit RequestWithdraw(msg.sender, _amountInSlisBnb);
+    }
+
+    function claimWithdraw(uint256 _idx) external override whenNotPaused {
+        address user = msg.sender;
+        WithdrawalRequest[] storage userRequests = userWithdrawalRequests[user];
+
+        require(_idx < userRequests.length, "Invalid index");
+
+        WithdrawalRequest storage withdrawRequest = userRequests[_idx];
+        uint256 uuid = withdrawRequest.uuid;
+        uint256 amountInSlisBnb = withdrawRequest.amountInSnBnb;
+
+        BotUndelegateRequest
+            storage botUndelegateRequest = uuidToBotUndelegateRequestMap[uuid];
+        require(botUndelegateRequest.endTime != 0, "Not able to claim yet");
+        userRequests[_idx] = userRequests[userRequests.length - 1];
+        userRequests.pop();
+
+        uint256 totalBnbToWithdraw_ = botUndelegateRequest.amount;
+        uint256 totalSlisBnbToBurn_ = botUndelegateRequest.amountInSnBnb;
+        uint256 amount = (totalBnbToWithdraw_ * amountInSlisBnb) /
+            totalSlisBnbToBurn_;
+
+        AddressUpgradeable.sendValue(payable(user), amount);
+
+        emit ClaimWithdrawal(user, _idx, amount);
+    }
+
+    function claimAllWithdrawals() external override whenNotPaused {
+        address user = msg.sender;
+        WithdrawalRequest[] storage userRequests = userWithdrawalRequests[user];
+
+	uint256 amount = 0;
+
+	require(userRequests.length > 0, "no request claimable");
+	uint256 count =userRequests.length;
+	while (count != 0) { // iterate from end to head
+	    uint idx_ = count - 1;
+	    WithdrawalRequest storage withdrawRequest = userRequests[idx_];
+	    uint256 uuid = withdrawRequest.uuid;
+	    uint256 amountInSlisBnb = withdrawRequest.amountInSnBnb;
+
+	    BotUndelegateRequest
+		storage botUndelegateRequest = uuidToBotUndelegateRequestMap[uuid];
+	    if (botUndelegateRequest.endTime == 0) {
+		continue;
+	    } else {
+		// swap and pop
+		userRequests[idx_] = userRequests[userRequests.length - 1];
+		userRequests.pop();
+
+		uint256 totalBnbToWithdraw_ = botUndelegateRequest.amount;
+		uint256 totalSlisBnbToBurn_ = botUndelegateRequest.amountInSnBnb;
+		uint256 _amount = (totalBnbToWithdraw_ * amountInSlisBnb) /
+		    totalSlisBnbToBurn_;
+		amount += _amount;
+	    }
+
+	    count -= 1;
+	}
+
+	require(amount > 0, "nothing to claim");
+        AddressUpgradeable.sendValue(payable(user), amount);
+
+        emit ClaimAllWithdrawals(user, amount);
+    }
+
+    /**
+     * @dev Bot uses this function to get amount of BNB to withdraw
+     * @return _uuid - unique id against which this Undelegation event was logged
+     * @return _amount - Amount of funds required to Unstake
+     */
+    function undelegate()
+        external
+        payable
+        override
+        whenNotPaused
+        onlyRole(BOT)
+        returns (uint256 _uuid, uint256 _amount)
+    {
+        uint256 relayFee = IStaking(NATIVE_STAKING).getRelayerFee();
+        uint256 relayFeeReceived = msg.value;
+
+        require(relayFeeReceived == relayFee, "Insufficient RelayFee");
+
+        _uuid = nextUndelegateUUID++; // post-increment : assigns the current value first and then increments
+        uint256 totalSlisBnbToBurn_ = totalSnBnbToBurn; // To avoid Reentrancy attack
+        _amount = convertSlisBnbToBnb(totalSlisBnbToBurn_);
+        _amount -= _amount % TEN_DECIMALS;
+
+        require(
+            _amount + reserveAmount >= IStaking(NATIVE_STAKING).getMinDelegation(),
+            "Insufficient Withdraw Amount"
+        );
+
+        uuidToBotUndelegateRequestMap[_uuid] = BotUndelegateRequest({
+            startTime: block.timestamp,
+            endTime: 0,
+            amount: _amount,
+            amountInSnBnb: totalSlisBnbToBurn_
+        });
+
+        totalDelegated -= _amount;
+        totalSnBnbToBurn = 0;
+
+        ISLisBNB(snBnb).burn(address(this), totalSlisBnbToBurn_);
+
+        // undelegate through native staking contract
+        IStaking(NATIVE_STAKING).undelegate{value: msg.value}(bcValidator, _amount + reserveAmount);
+
+        emit UndelegateReserve(reserveAmount);
+    }
+
+    /**
+     * @dev Bot uses this function to get amount of BNB to withdraw
+     * @param _validator - Validator to undelegate from
+     * @param _amt - Amount of BNB to undelegate
+     * @return _uuid - unique id against which this Undelegation event was logged
+     * @return _amount - Amount of funds required to Unstake
+     */
+    function undelegateFrom(address _validator, uint256 _amt)
+        external
+        payable
+        override
+        whenNotPaused
+        onlyRole(BOT)
+        returns (uint256 _uuid, uint256 _amount)
+    {
+        uint256 relayFee = IStaking(NATIVE_STAKING).getRelayerFee();
+        uint256 relayFeeReceived = msg.value;
+
+        require(relayFeeReceived == relayFee, "Insufficient RelayFee");
+
+        _uuid = nextUndelegateUUID++;
+        _amount = _amt - _amt % TEN_DECIMALS;
+        require(
+            _amount >= IStaking(NATIVE_STAKING).getMinDelegation(),
+            "Insufficient Withdraw Amount"
+        );
+	uint256 slisBnbToBurn = convertBnbToSlisBnb(_amount);
+	require(slisBnbToBurn <= totalSnBnbToBurn, "Not enough slisBNB to burn");
+        uuidToBotUndelegateRequestMap[_uuid] = BotUndelegateRequest({
+            startTime: block.timestamp,
+            endTime: 0,
+            amount: _amount, // BNB
+            amountInSnBnb: slisBnbToBurn // slisBNB
+        });
+	totalDelegated -= _amount;
+        totalSnBnbToBurn -= slisBnbToBurn;
+        ISLisBNB(snBnb).burn(address(this), slisBnbToBurn);
+
+	require(validators[_validator].amount >= _amount, "Insufficient amount");
+	validators[_validator].amount -= _amount;
+	slisBnbToBurn += spareSlisBnb;
+	for (uint256 i = nextClaimableIndex; i < withdrawalQueue.length; i++) {
+	    UserRequest memory req = withdrawalQueue[i];
+	    WithdrawalRequest storage reqData = userWithdrawalRequests[req.user][req.idx];
+	    if (reqData.amountInSnBnb <= slisBnbToBurn) {
+		reqData.uuid = _uuid; // request amount could be covered by this uuid
+		slisBnbToBurn -= reqData.amountInSnBnb;
+	    } else {
+		spareSlisBnb = slisBnbToBurn; // reset spare amount
+		break;
+	    }
+	}
+
+        // undelegate through native staking contract
+        IStaking(NATIVE_STAKING).undelegate{value: msg.value}(_validator, _amount);
+
+	emit Undelegate(_uuid, _amount);
+    }
+
+    function claimUndelegated()
+        external
+        override
+        whenNotPaused
+        onlyRole(BOT)
+        returns (uint256 _uuid, uint256 _amount)
+    {
+        uint256 undelegatedAmount = IStaking(NATIVE_STAKING).claimUndelegated();
+        require(undelegatedAmount > 0, "Nothing to undelegate");
+        for (uint256 i = confirmedUndelegatedUUID; i <= nextUndelegateUUID - 1; i++) {
+            BotUndelegateRequest
+                storage botUndelegateRequest = uuidToBotUndelegateRequestMap[i];
+            botUndelegateRequest.endTime = block.timestamp;
+            confirmedUndelegatedUUID++;
+        }
+
+	for (uint256 i = nextClaimableIndex; i < withdrawalQueue.length; i++) {
+	    UserRequest memory req = withdrawalQueue[i];
+	    WithdrawalRequest memory reqData = userWithdrawalRequests[req.user][req.idx];
+	    if ( reqData.uuid < confirmedUndelegatedUUID ) {
+		nextClaimableIndex += 1;
+	    } else {
+		break;
+	    }
+	}
+
+        _uuid = confirmedUndelegatedUUID;
+        _amount = undelegatedAmount;
+        emit ClaimUndelegated(_uuid, _amount);
+    }
+
+    function claimFailedDelegation(bool withReserve)
+        external
+        override
+        whenNotPaused
+        onlyRole(BOT)
+        returns (uint256 _amount)
+    {
+        uint256 failedAmount = IStaking(NATIVE_STAKING).claimUndelegated();
+        if (withReserve) {
+            require(failedAmount >= reserveAmount, "Wrong reserve amount for delegation");
+            amountToDelegate += failedAmount - reserveAmount;
+            totalDelegated -= failedAmount -reserveAmount;
+        } else {
+            amountToDelegate += failedAmount;
+            totalDelegated -= failedAmount;
+        }
+
+        emit ClaimFailedDelegation(failedAmount, withReserve);
+        return failedAmount;
+    }
+
+    /**
+     * @dev Deposit reserved funds to the contract
+     */
+    function depositReserve() external payable override whenNotPaused onlyRedirectAddress{
+        uint256 amount = msg.value;
+        require(amount > 0, "Invalid Amount");
+
+        totalReserveAmount += amount;
+    }
+
+    function withdrawReserve(uint256 amount) external override whenNotPaused onlyRedirectAddress{
+        require(amount <= totalReserveAmount, "Insufficient Balance");
+        totalReserveAmount -= amount;
+        AddressUpgradeable.sendValue(payable(msg.sender), amount);
+    }
+
+    function setReserveAmount(uint256 amount) external override onlyManager {
+        reserveAmount = amount;
+        emit SetReserveAmount(amount);
+    }
+
+    function proposeNewManager(address _address) external override onlyManager {
+        require(manager != _address, "Old address == new address");
+        require(_address != address(0), "zero address provided");
+
+        proposedManager = _address;
+
+        emit ProposeManager(_address);
+    }
+
+    function acceptNewManager() external override {
+        require(
+            msg.sender == proposedManager,
+            "Accessible only by Proposed Manager"
+        );
+
+        manager = proposedManager;
+        proposedManager = address(0);
+
+        emit SetManager(manager);
+    }
+
+    function setBotRole(address _address) external override {
+        require(_address != address(0), "zero address provided");
+
+        grantRole(BOT, _address);
+
+    }
+
+    function revokeBotRole(address _address) external override {
+        require(_address != address(0), "zero address provided");
+
+        revokeRole(BOT, _address);
+
+    }
+
+    /// @param _address - Beck32 decoding of Address of Validator Wallet on Beacon Chain with `0x` prefix
+    function setBCValidator(address _address)
+        external
+        override
+        onlyManager
+    {
+        require(bcValidator != _address, "Old address == new address");
+        require(_address != address(0), "zero address provided");
+
+        bcValidator = _address;
+
+        emit SetBCValidator(_address);
+    }
+
+    function setSynFee(uint256 _synFee)
+        external
+        override
+        onlyRole(DEFAULT_ADMIN_ROLE)
+    {
+        require(_synFee <= TEN_DECIMALS, "_synFee must not exceed 10000 (100%)");
+
+        synFee = _synFee;
+
+        emit SetSynFee(_synFee);
+    }
+
+    function setRedirectAddress(address _address)
+        external
+        override
+        onlyRole(DEFAULT_ADMIN_ROLE)
+    {
+        require(redirectAddress != _address, "Old address == new address");
+        require(_address != address(0), "zero address provided");
+
+        redirectAddress = _address;
+
+        emit SetRedirectAddress(_address);
+    }
+
+    function setRevenuePool(address _address)
+        external
+        override
+        onlyRole(DEFAULT_ADMIN_ROLE)
+    {
+        require(revenuePool != _address, "Old address == new address");
+        require(_address != address(0), "zero address provided");
+
+        revenuePool = _address;
+
+        emit SetRevenuePool(_address);
+    }
+
+    function whitelistValidator(address _address)
+        external
+        override
+        onlyRole(DEFAULT_ADMIN_ROLE)
+    {
+        require(!validators[_address].active, "Validator shoule be inactive");
+        require(_address != address(0), "zero address provided");
+
+        validators[_address].active = true;
+
+        emit WhitelistValidator(_address);
+    }
+
+    function disableValidator(address _address)
+        external
+        override
+        onlyRole(DEFAULT_ADMIN_ROLE)
+    {
+        require(validators[_address].active, "Validator is not active");
+
+        validators[_address].active = false;
+
+        emit DisableValidator(_address);
+    }
+
+    function removeValidator(address _address)
+        external
+        override
+        onlyRole(DEFAULT_ADMIN_ROLE)
+    {
+        require(!validators[_address].active, "Validator is should be inactive");
+        require(validators[_address].amount == 0, "Delegated amount remains");
+
+        delete validators[_address];
+
+        emit RemoveValidator(_address);
+    }
+
+    function getTotalPooledBnb() public view override returns (uint256) {
+        return (amountToDelegate + totalDelegated);
+    }
+
+    function getContracts()
+        external
+        view
+        override
+        returns (
+            address _manager,
+            address _slisBnb,
+            address _bcValidator
+        )
+    {
+        _manager = manager;
+        _slisBnb = snBnb;
+        _bcValidator = bcValidator;
+    }
+
+
+    function getBotUndelegateRequest(uint256 _uuid)
+        external
+        view
+        override
+        returns (BotUndelegateRequest memory)
+    {
+        return uuidToBotUndelegateRequestMap[_uuid];
+    }
+
+    /**
+     * @dev Retrieves all withdrawal requests initiated by the given address
+     * @param _address - Address of an user
+     * @return userWithdrawalRequests array of user withdrawal requests
+     */
+    function getUserWithdrawalRequests(address _address)
+        external
+        view
+        override
+        returns (WithdrawalRequest[] memory)
+    {
+        return userWithdrawalRequests[_address];
+    }
+
+    /**
+     * @dev Checks if the withdrawRequest is ready to claim
+     * @param _user - Address of the user who raised WithdrawRequest
+     * @param _idx - index of request in UserWithdrawls Array
+     * @return _isClaimable - if the withdraw is ready to claim yet
+     * @return _amount - Amount of BNB user would receive on withdraw claim
+     * @notice Use `getUserWithdrawalRequests` to get the userWithdrawlRequests Array
+     */
+    function getUserRequestStatus(address _user, uint256 _idx)
+        external
+        view
+        override
+        returns (bool _isClaimable, uint256 _amount)
+    {
+        WithdrawalRequest[] storage userRequests = userWithdrawalRequests[
+            _user
+        ];
+
+        require(_idx < userRequests.length, "Invalid index");
+
+        WithdrawalRequest storage withdrawRequest = userRequests[_idx];
+        uint256 uuid = withdrawRequest.uuid;
+        uint256 amountInSlisBnb = withdrawRequest.amountInSnBnb;
+
+        BotUndelegateRequest
+            storage botUndelegateRequest = uuidToBotUndelegateRequestMap[uuid];
+
+        // bot has triggered startUndelegation
+        if (botUndelegateRequest.amount > 0) {
+            uint256 totalBnbToWithdraw_ = botUndelegateRequest.amount;
+            uint256 totalSlisBnbToBurn_ = botUndelegateRequest.amountInSnBnb;
+            _amount = (totalBnbToWithdraw_ * amountInSlisBnb) / totalSlisBnbToBurn_;
+        }
+        // bot has not triggered startUndelegation yet
+        else {
+            _amount = convertSlisBnbToBnb(amountInSlisBnb);
+        }
+        _isClaimable = (botUndelegateRequest.endTime != 0);
+    }
+
+    function getSlisBnbWithdrawLimit()
+        external
+        view
+        override
+        returns (uint256 _slisBnbWithdrawLimit)
+    {
+        _slisBnbWithdrawLimit =
+            convertBnbToSlisBnb(totalDelegated) -
+            totalSnBnbToBurn;
+    }
+
+    /**
+     * @return relayFee required by Native Staking contract to transfer funds from BSC -> BC
+     */
+    function getRelayFee() public view override returns (uint256) {
+        return IStaking(NATIVE_STAKING).getRelayerFee();
+    }
+
+    /**
+     * @dev Calculates amount of SlisBnb for `_amount` Bnb
+     */
+    function convertBnbToSlisBnb(uint256 _amount)
+        public
+        view
+        override
+        returns (uint256)
+    {
+        uint256 totalShares = ISLisBNB(snBnb).totalSupply();
+        totalShares = totalShares == 0 ? 1 : totalShares;
+
+        uint256 totalPooledBnb = getTotalPooledBnb();
+        totalPooledBnb = totalPooledBnb == 0 ? 1 : totalPooledBnb;
+
+        uint256 amountInSlisBnb = (_amount * totalShares) / totalPooledBnb;
+
+        return amountInSlisBnb;
+    }
+
+    /**
+     * @dev Calculates amount of Bnb for `_amountInSlisBnb` SlisBnb
+     */
+    function convertSlisBnbToBnb(uint256 _amountInSlisBnb)
+        public
+        view
+        override
+        returns (uint256)
+    {
+        uint256 totalShares = ISLisBNB(snBnb).totalSupply();
+        totalShares = totalShares == 0 ? 1 : totalShares;
+
+        uint256 totalPooledBnb = getTotalPooledBnb();
+        totalPooledBnb = totalPooledBnb == 0 ? 1 : totalPooledBnb;
+
+        uint256 amountInBnb = (_amountInSlisBnb * totalPooledBnb) / totalShares;
+
+        return amountInBnb;
+    }
+
+    /**
+     * @dev Add the existing BC validator to whitelist
+     */
+    function whitelistBcValidator()
+        external
+        onlyRole(DEFAULT_ADMIN_ROLE)
+    {
+        require(!validators[bcValidator].active &&
+		validators[bcValidator].amount == 0,
+		"BC Validator whitelisted");
+        require(bcValidator != address(0), "zero address provided");
+
+        validators[bcValidator].active = true;
+        validators[bcValidator].amount = totalDelegated;
+
+        emit WhitelistValidator(bcValidator);
+    }
+
+    /**
+     * @dev Flips the pause state
+     */
+    function togglePause() external onlyRole(DEFAULT_ADMIN_ROLE) {
+        paused() ? _unpause() : _pause();
+    }
+
+    receive() external payable {
+        if (msg.sender != NATIVE_STAKING && msg.sender != redirectAddress) {
+            AddressUpgradeable.sendValue(payable(redirectAddress), msg.value);
+        }
+    }
+
+    modifier onlyManager() {
+        require(msg.sender == manager, "Accessible only by Manager");
+        _;
+    }
+
+    modifier onlyRedirectAddress() {
+        require(msg.sender == redirectAddress, "Accessible only by RedirectAddress");
+        _;
+    }
+}

--- a/contracts/interfaces/IStakeManager.sol
+++ b/contracts/interfaces/IStakeManager.sol
@@ -134,16 +134,16 @@ interface IStakeManager {
         view
         returns (bool _isClaimable, uint256 _amount);
 
-    function getSnBnbWithdrawLimit()
+    function getSlisBnbWithdrawLimit()
         external
         view
-        returns (uint256 _bnbXWithdrawLimit);
+        returns (uint256 _slisBnbWithdrawLimit);
 
-    function getTokenHubRelayFee() external view returns (uint256);
+    function getRelayFee() external view returns (uint256);
 
-    function convertBnbToSnBnb(uint256 _amount) external view returns (uint256);
+    function convertBnbToSlisBnb(uint256 _amount) external view returns (uint256);
 
-    function convertSnBnbToBnb(uint256 _amountInBnbX)
+    function convertSlisBnbToBnb(uint256 _amountInBnbX)
         external
         view
         returns (uint256);

--- a/contracts/interfaces/IStakeManager.sol
+++ b/contracts/interfaces/IStakeManager.sol
@@ -16,6 +16,16 @@ interface IStakeManager {
         uint256 startTime;
     }
 
+    struct ValidatorStatus {
+        uint256 amount;
+        bool active;
+    }
+
+    struct UserRequest {
+        address user;
+        uint256 idx;
+    }
+
     function initialize(
         address _snBnb,
         address _admin,
@@ -29,6 +39,11 @@ interface IStakeManager {
     function deposit() external payable;
 
     function delegate()
+        external
+        payable
+        returns (uint256 _amount);
+
+    function delegateTo(address validator, uint256 amount)
         external
         payable
         returns (uint256 _amount);
@@ -48,6 +63,11 @@ interface IStakeManager {
     function claimWithdraw(uint256 _idx) external;
 
     function undelegate()
+        external
+        payable
+        returns (uint256 _uuid, uint256 _amount);
+
+    function undelegateFrom(address _validator, uint256 _amt)
         external
         payable
         returns (uint256 _uuid, uint256 _amount);
@@ -78,9 +98,15 @@ interface IStakeManager {
 
     function setRevenuePool(address _address) external;
 
+    function getTotalPooledBnb() external view returns (uint256);
+
     function setRedirectAddress(address _address) external;
 
-    function getTotalPooledBnb() external view returns (uint256);
+    function whitelistValidator(address _address) external;
+
+    function disableValidator(address _address) external;
+
+    function removeValidator(address _address) external;
 
     function getContracts()
         external
@@ -122,6 +148,7 @@ interface IStakeManager {
 
     event Deposit(address _src, uint256 _amount);
     event Delegate(uint256 _amount);
+    event DelegateTo(address _validator, uint256 _amount);
     event ReDelegate(address _src, address _dest, uint256 _amount);
     event RequestWithdraw(address indexed _account, uint256 _amountInBnbX);
     event ClaimWithdrawal(
@@ -143,4 +170,7 @@ interface IStakeManager {
     event SetReserveAmount(uint256 _amount);
     event ClaimUndelegated(uint256 _uuid, uint256 _amount);
     event ClaimFailedDelegation(uint256 _amount, bool _withReserve);
+    event WhitelistValidator(address indexed _address);
+    event DisableValidator(address indexed _address);
+    event RemoveValidator(address indexed _address);
 }

--- a/contracts/interfaces/IStakeManager.sol
+++ b/contracts/interfaces/IStakeManager.sol
@@ -62,6 +62,8 @@ interface IStakeManager {
 
     function claimWithdraw(uint256 _idx) external;
 
+    function claimAllWithdrawals() external;
+
     function undelegate()
         external
         payable
@@ -156,6 +158,7 @@ interface IStakeManager {
         uint256 _idx,
         uint256 _amount
     );
+    event ClaimAllWithdrawals(address indexed _account, uint256 _amount);
     event Undelegate(uint256 _uuid, uint256 _amount);
     event Redelegate(uint256 _rewardsId, uint256 _amount);
     event SetManager(address indexed _address);

--- a/test/snStakeManager/access.ts
+++ b/test/snStakeManager/access.ts
@@ -7,7 +7,7 @@ import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 
 import { accountFixture, deployFixture } from "../fixture";
 
-describe("SnStakeManager::access", function() {
+describe("ListaStakeManager::access", function() {
   const ADDRESS_ZERO = ethers.constants.AddressZero;
 
   let mockSnBNB: MockContract;
@@ -21,13 +21,13 @@ describe("SnStakeManager::access", function() {
     this.addrs = addrs;
     this.deployer = deployer;
     const { deployMockContract } = await loadFixture(deployFixture);
-    mockSnBNB = await deployMockContract("SnBnb");
+    mockSnBNB = await deployMockContract("SLisBNB");
     admin = this.addrs[1];
     manager = this.addrs[2];
     bot = this.addrs[3];
 
     stakeManager = await upgrades.deployProxy(
-      await ethers.getContractFactory("SnStakeManager"),
+      await ethers.getContractFactory("ListaStakeManager"),
       [
         mockSnBNB.address,
         admin.address,

--- a/test/snStakeManager/setup.ts
+++ b/test/snStakeManager/setup.ts
@@ -5,7 +5,7 @@ import type { MockContract } from "@ethereum-waffle/mock-contract";
 
 import { accountFixture, deployFixture } from "../fixture";
 
-describe("SnStakeManager::setup", function() {
+describe("ListaStakeManager::setup", function() {
   const ADDRESS_ZERO = ethers.constants.AddressZero;
   const botRole = ethers.utils.id("BOT");
   const adminRole = ethers.constants.HashZero;
@@ -17,7 +17,7 @@ describe("SnStakeManager::setup", function() {
     this.addrs = addrs;
     this.deployer = deployer;
     const { deployMockContract } = await loadFixture(deployFixture);
-    mockSnBNB = await deployMockContract("SnBnb");
+    mockSnBNB = await deployMockContract("SLisBNB");
   });
 
   it("Can't deploy with zero contract", async function() {
@@ -81,14 +81,14 @@ describe("SnStakeManager::setup", function() {
     for (let i = 0; i < allArgs.length; i++) {
       await expect(
         upgrades.deployProxy(
-          await ethers.getContractFactory("SnStakeManager"),
+          await ethers.getContractFactory("ListaStakeManager"),
           allArgs[i]
         )
       ).to.be.revertedWith("zero address provided");
     }
 
     await expect(
-      upgrades.deployProxy(await ethers.getContractFactory("SnStakeManager"), [
+      upgrades.deployProxy(await ethers.getContractFactory("ListaStakeManager"), [
         this.addrs[0].address,
         this.addrs[1].address,
         this.addrs[2].address,
@@ -102,7 +102,7 @@ describe("SnStakeManager::setup", function() {
 
   it("Should be able to setup contract with properly configurations", async function() {
     const stakeManager = await upgrades.deployProxy(
-      await ethers.getContractFactory("SnStakeManager"),
+      await ethers.getContractFactory("ListaStakeManager"),
       [
         mockSnBNB.address,
         this.addrs[1].address, // admin

--- a/test/snStakeManager/staking-basic.ts
+++ b/test/snStakeManager/staking-basic.ts
@@ -8,7 +8,7 @@ import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { impersonateAccount } from "../helper";
 import { accountFixture, deployFixture } from "../fixture";
 
-describe("SnStakeManager::staking::basic", function() {
+describe("ListaStakeManager::staking::basic", function() {
   const ADDRESS_ZERO = ethers.constants.AddressZero;
   const RELAYER_FEE = "2000000000000000";
   const NATIVE_STAKING = "0x0000000000000000000000000000000000002001";
@@ -36,7 +36,7 @@ describe("SnStakeManager::staking::basic", function() {
       ethers.utils.parseEther("10").toHexString()
     );
     slisBnb = await upgrades.deployProxy(
-      await ethers.getContractFactory("SnBnb"),
+      await ethers.getContractFactory("SLisBNB"),
       [this.addrs[1].address]
     );
     await slisBnb.deployed();
@@ -48,7 +48,7 @@ describe("SnStakeManager::staking::basic", function() {
 
 
     stakeManager = await upgrades.deployProxy(
-      await ethers.getContractFactory("SnStakeManager"),
+      await ethers.getContractFactory("ListaStakeManager"),
       [
         slisBnb.address,
         admin.address,

--- a/test/snStakeManager/staking-basic.ts
+++ b/test/snStakeManager/staking-basic.ts
@@ -1,0 +1,201 @@
+import { expect } from "chai";
+import { ethers, upgrades } from "hardhat";
+import { Contract } from "ethers";
+import { loadFixture } from "ethereum-waffle";
+import type { MockContract } from "@ethereum-waffle/mock-contract";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+
+import { impersonateAccount } from "../helper";
+import { accountFixture, deployFixture } from "../fixture";
+
+describe("SnStakeManager::staking::basic", function() {
+  const ADDRESS_ZERO = ethers.constants.AddressZero;
+  const RELAYER_FEE = "2000000000000000";
+  const NATIVE_STAKING = "0x0000000000000000000000000000000000002001";
+
+  let mockNativeStaking: MockContract;
+  let slisBnb: Contract;
+  let stakeManager: Contract;
+  let admin: SignerWithAddress;
+  let manager: SignerWithAddress;
+  let bot: SignerWithAddress;
+  let user: SignerWithAddress;
+  let validator: string;
+  let nativeStakingSigner: SignerWithAddress;
+
+  before(async function() {
+    const { deployer, addrs } = await loadFixture(accountFixture);
+    this.addrs = addrs;
+    this.deployer = deployer;
+    const { deployMockContract } = await loadFixture(deployFixture);
+    mockNativeStaking = await deployMockContract("MockNativeStaking", {
+      address: NATIVE_STAKING,
+    });
+    nativeStakingSigner = await impersonateAccount(
+      mockNativeStaking.address,
+      ethers.utils.parseEther("10").toHexString()
+    );
+    slisBnb = await upgrades.deployProxy(
+      await ethers.getContractFactory("SnBnb"),
+      [this.addrs[1].address]
+    );
+    await slisBnb.deployed();
+    admin = this.addrs[1];
+    manager = this.addrs[2];
+    bot = this.addrs[3];
+    user = this.addrs[6];
+    validator = this.addrs[8].address;
+
+
+    stakeManager = await upgrades.deployProxy(
+      await ethers.getContractFactory("SnStakeManager"),
+      [
+        slisBnb.address,
+        admin.address,
+        manager.address,
+        bot.address,
+        100_000_000, // 1% sync fee to revenue pool
+        this.addrs[4].address,
+        this.addrs[5].address,
+      ]
+    );
+    await stakeManager.deployed();
+
+    // mock native staking contract behaviors
+    await Promise.all([
+      slisBnb.connect(admin).setStakeManager(stakeManager.address),
+      mockNativeStaking.mock.getRelayerFee.returns(RELAYER_FEE), // 0.002BNB relayer fee
+      mockNativeStaking.mock.getMinDelegation.returns(
+        ethers.utils.parseEther("0.5")
+      ),
+      mockNativeStaking.mock.delegate.returns(),
+      mockNativeStaking.mock.redelegate.returns(),
+      mockNativeStaking.mock.undelegate.returns(),
+    ]);
+  });
+
+
+  // 1. user deposit 0.5 BNB
+  it("Step 1 - Should be able to deposit", async function() {
+    expect(await stakeManager.convertBnbToSlisBnb(1)).to.equals(1);
+    const [balance1Before] = await Promise.all([
+      slisBnb.balanceOf(user.address),
+    ]);
+
+    await stakeManager.connect(user).deposit({
+      value: ethers.utils.parseEther("0.5"),
+    });
+    expect(await stakeManager.convertBnbToSlisBnb(1)).to.equals(1);
+    const [balance1After] = await Promise.all([
+      slisBnb.balanceOf(user.address),
+    ]);
+    expect(balance1After.sub(balance1Before)).to.equals(
+      ethers.utils.parseEther("0.5")
+    );
+  });
+
+  // 2. bot delegate 0.5 BNB to staking contract
+  it("Step 2 - Should be able to delegate to specified validator by bot", async function() {
+    await stakeManager
+      .connect(admin)
+      .whitelistValidator(validator);
+
+    //await stakeManager.connect(user).deposit({ value: ethers.utils.parseEther("5") });
+
+    const tx = await stakeManager
+      .connect(bot)
+      .delegateTo(validator, ethers.utils.parseEther("0.5"), {
+        value: RELAYER_FEE,
+      });
+
+    expect(tx)
+      .to.emit(stakeManager, "DelegateTo")
+      .withArgs(validator, ethers.utils.parseEther("0.5"));
+  });
+
+  // 3. user requests to withdraw 0.5 slisBnb
+  it("Step 3 - Should be able to request withdraw", async function() {
+    // approve first
+    await slisBnb
+      .connect(user)
+      .approve(stakeManager.address, ethers.constants.MaxUint256);
+    expect(await stakeManager.amountToDelegate()).to.equals(0);
+    expect(await slisBnb.totalSupply()).to.equals(
+      ethers.utils.parseEther("0.5")
+    );
+    const tx1 = await stakeManager
+      .connect(user)
+      .requestWithdraw(ethers.utils.parseEther("0.5"));
+
+    const res = await stakeManager.getUserWithdrawalRequests(
+      user.address
+    );
+
+    expect(res[0][0]).to.equals(ethers.constants.MaxUint256);
+    expect(res[0][1]).to.equals(ethers.utils.parseEther("0.5"));
+
+    await expect(stakeManager
+      .connect(user)
+      .requestWithdraw(ethers.utils.parseEther("0.2"))).to.be.revertedWith("Not enough BNB to withdraw");
+  });
+
+  // 4. bot undelegate 0.5 BNB from validator
+  it("Step 4 - Should be able to undelegate by bot", async function() {
+    await mockNativeStaking.mock.getMinDelegation.returns(ethers.utils.parseEther("0.5"));
+
+    await stakeManager.connect(bot).undelegateFrom(validator, ethers.utils.parseEther("0.5"),
+      { value: RELAYER_FEE });
+
+    const res = await stakeManager.getBotUndelegateRequest(0);
+    expect(res[0]).not.to.equals(0);
+    expect(res[1]).to.equals(0);
+    expect(res[2]).to.equals(ethers.utils.parseEther("0.5"));
+    expect(res[3]).to.equals(ethers.utils.parseEther("0.5"));
+  });
+
+
+  // 5. bot claims
+  it("Step 5 - Should be able to claim undelegated by bot", async function() {
+    const claimedAmount = ethers.utils
+      .parseEther("1.216499999999999999")
+      .toString();
+    const uuid = await stakeManager.confirmedUndelegatedUUID();
+    //    const botReq = await stakeManager.getBotUndelegateRequest(uuid);
+    //    console.log(botReq);
+
+    await mockNativeStaking.mock.claimUndelegated.returns(claimedAmount);
+    await expect(stakeManager.connect(bot).claimUndelegated()).to.emit(stakeManager, "ClaimUndelegated").withArgs(uuid + 1, claimedAmount);
+    // mock send reward
+    await nativeStakingSigner.sendTransaction({
+      to: stakeManager.address,
+      value: claimedAmount,
+    });
+  });
+
+
+  // 6. user claims
+  it("Step 6 - Should be able to claim withdraw by user", async function() {
+    const requests = await stakeManager.getUserWithdrawalRequests(user.address);
+    const uuid = await stakeManager.confirmedUndelegatedUUID();
+    const botReq = await stakeManager.getBotUndelegateRequest(uuid - 1);
+
+    const status1 = await stakeManager.getUserRequestStatus(
+      user.address,
+      0
+    );
+    expect(status1[0]).to.equals(true);
+    expect(status1[1]).to.equals(ethers.utils.parseEther("0.5"));
+
+    await expect(stakeManager.connect(user).claimAllWithdrawals())
+      .to.emit(stakeManager, "ClaimAllWithdrawals")
+      .withArgs(user.address, ethers.utils.parseEther("0.5"));
+    // const tx1 = await stakeManager.connect(user).claimWithdraw(0);
+    // expect(tx1)
+    //   .to.emit(stakeManager, "ClaimWithdrawal")
+    //   .withArgs(
+    //     user.address,
+    //     0,
+    //     ethers.utils.parseEther("0.5")
+    //   );
+  });
+});


### PR DESCRIPTION
SnStakeManager only supports delegating to one specific validator in current implementation, this PR adds the support for multiple validators:

* Add methods to add/remove validator
* Add methods to delegateTo / undelegateFrom given validator
* Rename SnStakeManager to ListaStakeManger, snBnb to slisBnb