### PR TITLE
Audit fix for multi-validator

### DIFF
--- a/contracts/ListaStakeManager.sol
+++ b/contracts/ListaStakeManager.sol
@@ -74,7 +74,7 @@ contract ListaStakeManager is
     }
 
     /**
-     * @param _slisBnb - Address of SlisBnb Token on Binance Smart Chain
+     * @param _slisBnb - Address of SlisBnb Token on BNB Smart Chain
      * @param _admin - Address of the admin
      * @param _manager - Address of the manager
      * @param _bot - Address of the Bot
@@ -177,8 +177,6 @@ contract ListaStakeManager is
         require(validators[dstValidator], "Inactive dst validator");
 
         uint256 shares = convertBnbToShares(srcValidator, _amount);
-        uint256 feeCharge = getRedelegateFee(_amount);
-        require(_amount >= feeCharge, "Insufficient Fee");
 
         // redelegate through native staking contract
         IStakeHub(STAKE_HUB).redelegate(srcValidator, dstValidator, shares, delegateVotePower);

--- a/contracts/ListaStakeManager.sol
+++ b/contracts/ListaStakeManager.sol
@@ -311,7 +311,6 @@ contract ListaStakeManager is
      * @dev Bot uses this function to undelegate BNB from a validator
      * @param _operator - Operator address of validator to undelegate from
      * @param _amount - Amount of bnb to undelegate
-     * @return bnbToUndelegate - bnb amount to be undelegated by bot
      * @notice Bot should invoke `undelegate()` first to process old requests before calling this function
      */
     function undelegateFrom(address _operator, uint256 _amount)
@@ -319,7 +318,6 @@ contract ListaStakeManager is
         override
         whenNotPaused
         onlyRole(BOT)
-        returns (uint256)
     {
         require(totalSnBnbToBurn == 0, "Old requests should be processed first");
         require(_amount <= (getAmountToUndelegate() + reserveAmount), "Given bnb amount is too large");
@@ -330,7 +328,6 @@ contract ListaStakeManager is
         IStakeHub(STAKE_HUB).undelegate(_operator, _shares);
 
         emit UndelegateFrom(_operator, _actualBnbAmount, _shares);
-        return getAmountToUndelegate();
     }
 
     /**

--- a/contracts/ListaStakeManager.sol
+++ b/contracts/ListaStakeManager.sol
@@ -705,9 +705,6 @@ contract ListaStakeManager is
      */
     function getAmountToUndelegate() public view override returns (uint256 _amountToUndelegate) {
         uint256 nextIndex = requestIndexMap[nextConfirmedRequestUUID];
-        if (nextIndex == withdrawalQueue.length) {
-            return 0;
-        }
         uint256 totalAmountToWithdraw = 0;
         for (uint256 i = nextIndex; i < withdrawalQueue.length; ++i) {
             UserRequest storage req = withdrawalQueue[i];
@@ -716,6 +713,8 @@ contract ListaStakeManager is
         }
 
         _amountToUndelegate = totalAmountToWithdraw - unbondingBnb;
+
+        return _amountToUndelegate >= undelegatedQuota ? _amountToUndelegate - undelegatedQuota : 0;
     }
 
     /**

--- a/contracts/ListaStakeManager.sol
+++ b/contracts/ListaStakeManager.sol
@@ -31,7 +31,7 @@ contract ListaStakeManager is
     uint256 public amountToDelegate; // total BNB to delegate for next batch
 
     uint256 public requestUUID; // global UUID for each user withdrawal request
-    uint256 public nextConfirmedRequestUUID; // next confirmed UUID for user withdrawal requests
+    uint256 public nextConfirmedRequestUUID; // req whose uuid < nextConfirmedRequestUUID is claimable
 
     uint256 public reserveAmount; // buffer amount for undelegation
     uint256 public totalReserveAmount;
@@ -286,7 +286,8 @@ contract ListaStakeManager is
         returns (uint256 _uuid, uint256 _amount)
     {
         require(totalSnBnbToBurn > 0, "Nothing to undelegate");
-        _uuid = requestUUID; // pin uuid to the last confirmed uuid+1
+        _uuid = withdrawalQueue.length != 0 ? withdrawalQueue[0].uuid - 1: requestUUID;
+        // Pin _uuid to the last `nextUndelegateUUID` in old version
 
         uint256 totalSlisBnbToBurn_ = totalSnBnbToBurn; // To avoid Reentrancy attack
         uint256 bnbAmount_ = convertSnBnbToBnb(totalSlisBnbToBurn_);

--- a/contracts/interfaces/IStakeManager.sol
+++ b/contracts/interfaces/IStakeManager.sol
@@ -51,7 +51,8 @@ interface IStakeManager {
         returns (uint256 _uuid, uint256 _shares);
 
     function undelegateFrom(address _operator, uint256 _amount)
-        external;
+        external
+        returns (uint256 _actualBnbAmount);
 
     function claimUndelegated(address _validator) external returns (uint256, uint256);
 

--- a/contracts/interfaces/IStakeManager.sol
+++ b/contracts/interfaces/IStakeManager.sol
@@ -49,8 +49,7 @@ interface IStakeManager {
         returns (uint256 _uuid, uint256 _shares);
 
     function undelegateFrom(address _operator, uint256 _amount)
-        external
-        returns (uint256 bnbToUndelegate);
+        external;
 
     function claimUndelegated(address _validator) external returns (uint256, uint256);
 


### PR DESCRIPTION
Fixed following issues:

* Potential ddos attack on `claimUndeleaged` 
* Wrong operator address in `undelegateFrom`
* Unnecessary check in `redelegate`
* Should not increment `_uuid` in `undelegate`
* Unused variable `nextUndelegatedRequestIndex`
* Fixed logic of `getAmountToUndelegate`