### PR TITLE
+ Added unpause() method

### DIFF
--- a/contracts/ListaStakeManager.sol
+++ b/contracts/ListaStakeManager.sol
@@ -867,10 +867,18 @@ contract ListaStakeManager is IStakeManager, Initializable, PausableUpgradeable,
         return _amount * stakeHub.redelegateFeeRate() / stakeHub.REDELEGATE_FEE_RATE_BASE();
     }
 
+    /// @dev to be deprecated. Use pause() and unpause() instead.
+    /// @dev backward compatible purpose only
+    function togglePause() external onlyRole(DEFAULT_ADMIN_ROLE) {
+        paused() ? _unpause() : _pause();
+    }
+
     /**
-     * @dev Resumes the contract by Guardian
+     * @dev Resumes the contract by MANAGER
+     * @notice MANAGER can be our EmergencySwitchHub Contract as well
+     *         the ES-hub contract is limited to unpause the ListaStakeManager only
      */
-    function unpause() external onlyRole(GUARDIAN) {
+    function unpause() external onlyRole(MANAGER) {
         _unpause();
     }
 

--- a/contracts/ListaStakeManager.sol
+++ b/contracts/ListaStakeManager.sol
@@ -875,6 +875,13 @@ contract ListaStakeManager is IStakeManager, Initializable, PausableUpgradeable,
     }
 
     /**
+     * @dev Resumes the contract by Guardian
+     */
+    function unpause() external onlyRole(GUARDIAN) {
+        _unpause();
+    }
+
+    /**
      * @dev Pauses the contract by Guardian
      */
     function pause() external onlyRole(GUARDIAN) {

--- a/contracts/ListaStakeManager.sol
+++ b/contracts/ListaStakeManager.sol
@@ -868,13 +868,6 @@ contract ListaStakeManager is IStakeManager, Initializable, PausableUpgradeable,
     }
 
     /**
-     * @dev Flips the pause state by Admin
-     */
-    function togglePause() external onlyRole(DEFAULT_ADMIN_ROLE) {
-        paused() ? _unpause() : _pause();
-    }
-
-    /**
      * @dev Resumes the contract by Guardian
      */
     function unpause() external onlyRole(GUARDIAN) {

--- a/test/foundry/ListaStakeManager.t.sol
+++ b/test/foundry/ListaStakeManager.t.sol
@@ -11,6 +11,13 @@ import "../../contracts/mock/MockClaim.sol";
 
 import {IStakeManager} from "../../contracts/interfaces/IStakeManager.sol";
 
+interface IStakeManagerExtended is IStakeManager {
+    function grantRole(bytes32 role, address account) external;
+    function pause() external;
+    function unpause() external;
+    function paused() external view returns (bool);
+}
+
 contract ListaStakeManagerTest is Test {
     address private constant STAKE_HUB = 0x0000000000000000000000000000000000002002;
 
@@ -24,6 +31,8 @@ contract ListaStakeManagerTest is Test {
     address public bot = address(0x5A11AA3);
     address public revenuePool = address(0x5A11AA4);
     address public validator = address(0x5A11AA6);
+    address public guardian = makeAddr("guardian");
+    bytes32 public constant GUARDIAN = keccak256("GUARDIAN");
 
     uint256 public synFee = 500000000;
 
@@ -67,8 +76,27 @@ contract ListaStakeManagerTest is Test {
 
         claimMock = new ClaimMock();
 
+        vm.prank(admin);
+        IStakeManagerExtended(address(stakeManager)).grantRole(GUARDIAN, guardian);
+
         // Modify `nextConfirmedRequestUUID` to have it start from 1
         vm.store(address(stakeManager), bytes32(uint256(205)), bytes32(uint256(1)));
+    }
+
+    function test_pause_and_unpause() public {
+        IStakeManagerExtended _stakeManager = IStakeManagerExtended(address(stakeManager));
+
+        vm.prank(guardian);
+        _stakeManager.pause();
+        vm.stopPrank();
+
+        assertTrue(_stakeManager.paused());
+
+        vm.prank(guardian);
+        _stakeManager.unpause();
+        vm.stopPrank();
+
+        assertFalse(_stakeManager.paused());
     }
 
     function test_deposit() public {


### PR DESCRIPTION
## 📄 Description
Added unpause() method to ListaStakeManager, make it to accommate the functionality of EmergencySwitchHub contract


## 🧠 Rationale
Unify all pause/unpause functions into one contract: EmergencySwitchHub.



## 🧪 Example / Testing
```forge test -vv --mc ListaStakeManagerTest --mt test_pause_and_unpause```



## 🧬 Changes Summary
* added unpause() method to ListaStakeManager.sol
