### PR TITLE
fix: add pure modifier to library functions

### DIFF
--- a/contracts/libraries/SLisLibrary.sol
+++ b/contracts/libraries/SLisLibrary.sol
@@ -6,7 +6,7 @@ library SLisLibrary {
         uint256 _profit,
         uint256 _synFee,
         uint256 _decimals // 1e10
-    ) public returns (uint256 _fee) {
+    ) public pure returns (uint256 _fee) {
         _fee = (_profit * _synFee) / _decimals;
     }
 
@@ -14,12 +14,12 @@ library SLisLibrary {
         uint256 _principal,
         uint256 _annualRate,
         uint256 _decimals // 1e10
-    ) public returns (uint256 _fee) {
+    ) public pure returns (uint256 _fee) {
         _fee = (_principal * _annualRate) / 365 / _decimals;
     }
 
     function calculateFee(uint256 _principal, uint256 _profit, uint256 _annualRate, uint256 _synFee, uint256 _decimals)
-        public
+        public pure
         returns (uint256 _fee)
     {
         uint256 _feeFromAPY = calculateFeeFromAPY(_principal, _annualRate, _decimals);


### PR DESCRIPTION
The SLisLibrary functions calculateFeeFromDailyProfit, calculateFeeFromAPY, and calculateFee only perform pure calculations without reading or modifying state. Adding the 'pure' modifier:

- Improves code clarity by explicitly declaring function behavior
- Enables compiler optimizations
- Follows Solidity best practices for library functions
- Reduces gas costs when called from other contracts

## 📄 Description
Briefly describe the purpose of this PR. Include context and what it solves.



## 🧠 Rationale
Explain the motivation and necessity of the change. Why was this needed? What problem does it solve?



## 🧪 Example / Testing
If applicable, provide test scenarios, CLI commands, or example contract interactions.



## 🧬 Changes Summary
Notable changes:
* add each change in a bullet point here
* ...
