### PR TITLE
Feature: gate instant withdrawal behind a whitelist

### DIFF
--- a/contracts/ListaStakeManager.sol
+++ b/contracts/ListaStakeManager.sol
@@ -123,6 +123,13 @@ contract ListaStakeManager is IStakeManager, Initializable, PausableUpgradeable,
     // manager role to refund commission
     bytes32 public constant MANAGER = keccak256("MANAGER");
 
+    // Whitelist of users allowed to use instant withdrawal
+    // user address => true/false
+    mapping(address => bool) public instantWhitelist;
+
+    // When true, bypass the instant-withdrawal whitelist (open to all); false (default) enforces it
+    bool public instantWhitelistOff;
+
     struct Refund {
         uint256 dailySlisBnb; // daily slisBnb to be burned
         uint256 remainingSlisBnb; // remaining slisBnb amount to be burned
@@ -295,6 +302,10 @@ contract ListaStakeManager is IStakeManager, Initializable, PausableUpgradeable,
      * @notice User must have approved this contract to spend SlisBnb
      */
     function instantWithdraw(uint256 _amountInSlisBnb) external whenNotPaused returns (uint256) {
+        if (!instantWhitelistOff && !instantWhitelist[msg.sender]) {
+            revert ErrorsLib.NotWhitelisted();
+        }
+
         uint256 withdrawFee = (_amountInSlisBnb * instantWithdrawFeeRate) / TEN_DECIMALS;
         instantWithdrawFee += withdrawFee;
 
@@ -710,6 +721,27 @@ contract ListaStakeManager is IStakeManager, Initializable, PausableUpgradeable,
         instantWithdrawFeeRate = _instantWithdrawFeeRate;
 
         emit SetInstantWithdrawFeeRate(_instantWithdrawFeeRate);
+    }
+
+    /**
+     * @dev Sets whether a user is allowed to use instant withdrawal; only manager can call this function
+     * @param _user - The user address to update
+     * @param _status - true to whitelist the user, false to remove
+     */
+    function setInstantWhitelist(address _user, bool _status) external override onlyRole(MANAGER) {
+        if (_user == address(0)) revert ErrorsLib.ZeroAddress();
+
+        instantWhitelist[_user] = _status;
+        emit SetInstantWhitelist(_user, _status);
+    }
+
+    /**
+     * @dev Enables or disables the instant-withdrawal whitelist globally; only admin can call this function
+     * @param _off - true to bypass the whitelist (open to everyone), false to enforce it
+     */
+    function setInstantWhitelistOff(bool _off) external override onlyRole(DEFAULT_ADMIN_ROLE) {
+        instantWhitelistOff = _off;
+        emit SetInstantWhitelistOff(_off);
     }
 
     function getTotalPooledBnb() public view override returns (uint256) {

--- a/contracts/ListaStakeManager.sol
+++ b/contracts/ListaStakeManager.sol
@@ -724,11 +724,11 @@ contract ListaStakeManager is IStakeManager, Initializable, PausableUpgradeable,
     }
 
     /**
-     * @dev Sets whether a user is allowed to use instant withdrawal; only manager can call this function
+     * @dev Sets whether a user is allowed to use instant withdrawal; only admin can call this function
      * @param _user - The user address to update
      * @param _status - true to whitelist the user, false to remove
      */
-    function setInstantWhitelist(address _user, bool _status) external override onlyRole(MANAGER) {
+    function setInstantWhitelist(address _user, bool _status) external override onlyRole(DEFAULT_ADMIN_ROLE) {
         if (_user == address(0)) revert ErrorsLib.ZeroAddress();
 
         instantWhitelist[_user] = _status;

--- a/contracts/interfaces/IStakeManager.sol
+++ b/contracts/interfaces/IStakeManager.sol
@@ -80,6 +80,10 @@ interface IStakeManager {
 
     function setInstantWithdrawFeeRate(uint256 _feeRate) external;
 
+    function setInstantWhitelist(address _user, bool _status) external;
+
+    function setInstantWhitelistOff(bool _off) external;
+
     function getBotUndelegateRequest(uint256 _uuid) external view returns (BotUndelegateRequest memory);
 
     function getUserWithdrawalRequests(address _address) external view returns (WithdrawalRequest[] memory);
@@ -143,4 +147,6 @@ interface IStakeManager {
     event ClaimWithdrawFee(address indexed _recipient, uint256 _amount);
     event SetBufferSizePct(uint256 _bufferSizePct);
     event SetInstantWithdrawFeeRate(uint256 _feeRate);
+    event SetInstantWhitelist(address indexed _user, bool _status);
+    event SetInstantWhitelistOff(bool _off);
 }

--- a/contracts/libraries/ErrorsLib.sol
+++ b/contracts/libraries/ErrorsLib.sol
@@ -14,4 +14,5 @@ library ErrorsLib {
     error AmountTooLarge();
     error InvalidSynFee();
     error UnclaimableRequest();
+    error NotWhitelisted();
 }

--- a/test/foundry/ListaStakeManager.t.sol
+++ b/test/foundry/ListaStakeManager.t.sol
@@ -426,6 +426,50 @@ contract ListaStakeManagerTest is Test {
         assertEq(abi.decode(entries[0].data, (uint256)), 10000000);
     }
 
+    function test_setInstantWhitelist() public {
+        assertFalse(stakeManager.instantWhitelist(user_A));
+
+        // only MANAGER can manage the whitelist
+        vm.prank(user_A);
+        vm.expectRevert();
+        stakeManager.setInstantWhitelist(user_A, true);
+
+        // zero address is rejected
+        vm.prank(manager);
+        vm.expectRevert("ZeroAddress()");
+        stakeManager.setInstantWhitelist(address(0), true);
+
+        // manager whitelists user_A
+        vm.prank(manager);
+        stakeManager.setInstantWhitelist(user_A, true);
+        assertTrue(stakeManager.instantWhitelist(user_A));
+
+        // manager removes user_A
+        vm.prank(manager);
+        stakeManager.setInstantWhitelist(user_A, false);
+        assertFalse(stakeManager.instantWhitelist(user_A));
+    }
+
+    function test_setInstantWhitelistOff() public {
+        // whitelist is enforced by default
+        assertFalse(stakeManager.instantWhitelistOff());
+
+        // only DEFAULT_ADMIN_ROLE can flip the global switch
+        vm.prank(manager);
+        vm.expectRevert();
+        stakeManager.setInstantWhitelistOff(true);
+
+        // admin disables the whitelist globally
+        vm.prank(admin);
+        stakeManager.setInstantWhitelistOff(true);
+        assertTrue(stakeManager.instantWhitelistOff());
+
+        // admin re-enables enforcement
+        vm.prank(admin);
+        stakeManager.setInstantWhitelistOff(false);
+        assertFalse(stakeManager.instantWhitelistOff());
+    }
+
     function test_instantWithrdraw() public {
         vm.mockCall(
             STAKE_HUB, abi.encodeWithSignature("getValidatorCreditContract(address)", validator_A), abi.encode(credit_A)
@@ -489,6 +533,29 @@ contract ListaStakeManagerTest is Test {
         assertEq(stakeManager.amountToDelegate(), 117 ether, "buffer size should be 116 Bnb");
         assertEq(stakeManager.getTotalPooledBnb(), 1160 ether);
         assertEq(slisBnb.balanceOf(user_A), 160 ether);
+
+        // by default the whitelist is enforced: a non-whitelisted user is rejected
+        assertFalse(stakeManager.instantWhitelistOff());
+        vm.prank(user_A);
+        vm.expectRevert("NotWhitelisted()");
+        stakeManager.instantWithdraw(6 ether);
+
+        // global switch off: the whitelist is bypassed, so a non-whitelisted user
+        // passes the gate and only fails later on the min-amount check
+        vm.prank(admin);
+        stakeManager.setInstantWhitelistOff(true);
+        vm.prank(user_A);
+        vm.expectRevert("AmountTooSmall()");
+        stakeManager.instantWithdraw(0);
+
+        // re-enable enforcement
+        vm.prank(admin);
+        stakeManager.setInstantWhitelistOff(false);
+
+        // whitelist user_A for instant withdrawal
+        vm.prank(manager);
+        stakeManager.setInstantWhitelist(user_A, true);
+        assertTrue(stakeManager.instantWhitelist(user_A));
 
         vm.startPrank(user_A);
         slisBnb.approve(address(stakeManager), 6 ether);

--- a/test/foundry/ListaStakeManager.t.sol
+++ b/test/foundry/ListaStakeManager.t.sol
@@ -429,23 +429,23 @@ contract ListaStakeManagerTest is Test {
     function test_setInstantWhitelist() public {
         assertFalse(stakeManager.instantWhitelist(user_A));
 
-        // only MANAGER can manage the whitelist
+        // only DEFAULT_ADMIN_ROLE can manage the whitelist
         vm.prank(user_A);
         vm.expectRevert();
         stakeManager.setInstantWhitelist(user_A, true);
 
         // zero address is rejected
-        vm.prank(manager);
+        vm.prank(admin);
         vm.expectRevert("ZeroAddress()");
         stakeManager.setInstantWhitelist(address(0), true);
 
-        // manager whitelists user_A
-        vm.prank(manager);
+        // admin whitelists user_A
+        vm.prank(admin);
         stakeManager.setInstantWhitelist(user_A, true);
         assertTrue(stakeManager.instantWhitelist(user_A));
 
-        // manager removes user_A
-        vm.prank(manager);
+        // admin removes user_A
+        vm.prank(admin);
         stakeManager.setInstantWhitelist(user_A, false);
         assertFalse(stakeManager.instantWhitelist(user_A));
     }
@@ -455,7 +455,7 @@ contract ListaStakeManagerTest is Test {
         assertFalse(stakeManager.instantWhitelistOff());
 
         // only DEFAULT_ADMIN_ROLE can flip the global switch
-        vm.prank(manager);
+        vm.prank(user_A);
         vm.expectRevert();
         stakeManager.setInstantWhitelistOff(true);
 
@@ -553,7 +553,7 @@ contract ListaStakeManagerTest is Test {
         stakeManager.setInstantWhitelistOff(false);
 
         // whitelist user_A for instant withdrawal
-        vm.prank(manager);
+        vm.prank(admin);
         stakeManager.setInstantWhitelist(user_A, true);
         assertTrue(stakeManager.instantWhitelist(user_A));
 


### PR DESCRIPTION
## 📄 Description
Introduce **instant BNB withdrawals**: users burn slisBNB and receive BNB immediately (minus a fee) instead of waiting the 7-day unbonding period. Liquidity is served from a **buffer pool** (`amountToDelegate`), which only grows from incoming deposits. Instant withdrawal is **gated by an opt-in whitelist that is enforced by default**.

## 🧠 Rationale
Today users must wait ~7 days to receive BNB after `requestWithdraw`. Instant withdrawal lets them exit immediately by paying a fee, using the un-delegated buffer as the liquidity source. The whitelist enables a controlled rollout to selected users first, with a global kill-switch to open it to everyone later.

## 🧬 Changes Summary
**Instant withdrawal + buffer pool**
- `delegateTo` now keeps a buffer: it reverts (`BufferTooSmall`) if delegating would drop the buffer below `bufferSizePct * totalPooledBnb`.
- New `instantWithdraw(amountInSlisBnb)`: burns slisBNB, deducts a fee, sends BNB from the buffer at the current exchange rate.
- New config (all `DEFAULT_ADMIN_ROLE`): `bufferSizePct` (`setBufferSizePct`), `instantWithdrawFeeRate` (`setInstantWithdrawFeeRate`); fee accrues in `instantWithdrawFee` and is swept by BOT via `claimWithdrawFee` → `revenuePool`.
- `minBnb` gates both normal and instant withdrawals.

**Whitelist gating** (both controls gated on `DEFAULT_ADMIN_ROLE`)
- `instantWhitelist` mapping + `setInstantWhitelist(user, status)`; `instantWithdraw` reverts `NotWhitelisted` for non-whitelisted callers.
- `instantWhitelistOff` global switch via `setInstantWhitelistOff(bool)` bypasses the whitelist entirely. Defaults to `false`, so the whitelist is **enforced the moment the upgrade takes effect — no migration call needed** (fail-closed).


## 🧪 Testing
~~~bash
forge test --match-contract ListaStakeManagerTest -vvv
~~~
Covers deposit/delegate buffer behaviour, `instantWithdraw` (enforce vs. bypass paths, fee, min-amount), whitelist + global-switch setters, and access control. All unit tests pass; `forge fmt --check` is clean.

## 📐 Contract size
Runtime **23,339 B** / 24,576 B limit — **1,237 B** margin.